### PR TITLE
feat: Refactor web search and fix UI blinking

### DIFF
--- a/lib/core/models/message_model.dart
+++ b/lib/core/models/message_model.dart
@@ -9,6 +9,7 @@ class Message {
   final DateTime timestamp;
   final bool isStreaming;
   final bool hasError;
+  final WebSearchResult? webSearchResult; // Added this field
 
   const Message({
     required this.id,
@@ -17,6 +18,7 @@ class Message {
     required this.timestamp,
     this.isStreaming = false,
     this.hasError = false,
+    this.webSearchResult, // Added to constructor
   });
 
   Message copyWith({
@@ -26,6 +28,7 @@ class Message {
     DateTime? timestamp,
     bool? isStreaming,
     bool? hasError,
+    WebSearchResult? webSearchResult,
   }) {
     return Message(
       id: id ?? this.id,
@@ -34,6 +37,7 @@ class Message {
       timestamp: timestamp ?? this.timestamp,
       isStreaming: isStreaming ?? this.isStreaming,
       hasError: hasError ?? this.hasError,
+      webSearchResult: webSearchResult ?? this.webSearchResult,
     );
   }
 
@@ -73,6 +77,22 @@ class Message {
     );
   }
 
+  factory Message.fromJson(Map<String, dynamic> json, Map<String, dynamic> metadata) {
+    WebSearchResult? webSearchResult;
+    if (metadata['webSearchResult'] != null) {
+      webSearchResult = WebSearchResult.fromJson(metadata['webSearchResult']);
+    }
+
+    return Message(
+      id: json['id'],
+      content: json['content'],
+      type: json['role'] == 'user' ? MessageType.user : MessageType.assistant,
+      timestamp: DateTime.parse(json['created_at']),
+      hasError: json['hasError'] ?? false,
+      webSearchResult: webSearchResult,
+    );
+  }
+
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
@@ -83,18 +103,5 @@ class Message {
   int get hashCode => id.hashCode;
 }
 
-// A special message type to hold web search results
-class WebSearchMessage extends Message {
-  final WebSearchResult searchResult;
-  final String query;
-
-  WebSearchMessage({
-    required super.id,
-    required this.query,
-    required this.searchResult,
-  }) : super(
-          content: 'Web search results for "$query"',
-          type: MessageType.assistant,
-          timestamp: DateTime.now(),
-        );
-}
+// The WebSearchMessage class has been removed as its functionality
+// is now merged into the main Message class.

--- a/lib/core/models/web_search_result_model.dart
+++ b/lib/core/models/web_search_result_model.dart
@@ -24,6 +24,14 @@ class WebSearchResult {
           .toList(),
     );
   }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'web_results': webPages.map((item) => item.toJson()).toList(),
+      'news_results': newsArticles.map((item) => item.toJson()).toList(),
+      'image_results': images.map((item) => item.toJson()).toList(),
+    };
+  }
 }
 
 class WebPageResult {
@@ -43,6 +51,14 @@ class WebPageResult {
       link: json['link'] ?? '',
       snippet: json['snippet'] ?? '',
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'title': title,
+      'link': link,
+      'snippet': snippet,
+    };
   }
 }
 
@@ -67,6 +83,15 @@ class NewsArticleResult {
       imageUrl: json['imageUrl'] ?? '',
     );
   }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'title': title,
+      'link': link,
+      'source': source,
+      'imageUrl': imageUrl,
+    };
+  }
 }
 
 class ImageResult {
@@ -83,5 +108,12 @@ class ImageResult {
       link: json['link'] ?? '',
       imageUrl: json['imageUrl'] ?? '',
     );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'link': link,
+      'imageUrl': imageUrl,
+    };
   }
 }

--- a/lib/core/services/chat_history_service.dart
+++ b/lib/core/services/chat_history_service.dart
@@ -253,6 +253,8 @@ class ChatHistoryService extends ChangeNotifier {
             return FlashcardMessage.fromJson(json, metadata!);
           case 'quiz':
             return QuizMessage.fromJson(json, metadata!);
+          case 'web_search':
+            return Message.fromJson(json, metadata);
           default:
             return Message(
               id: json['id'],
@@ -354,6 +356,11 @@ class ChatHistoryService extends ChangeNotifier {
           'type': 'quiz',
           'prompt': message.prompt,
           'questions': message.questions.map((q) => q.toJson()).toList(),
+        };
+      } else if (message.webSearchResult != null) {
+        data['metadata'] = {
+          'type': 'web_search',
+          'webSearchResult': message.webSearchResult!.toJson(),
         };
       }
 

--- a/lib/features/main/pages/main_page.dart
+++ b/lib/features/main/pages/main_page.dart
@@ -26,9 +26,16 @@ class _MainPageState extends State<MainPage> with TickerProviderStateMixin {
   final GlobalKey<ScaffoldState> _scaffoldKey = GlobalKey<ScaffoldState>();
   bool _isForceUpdateRequired = false;
 
+  // Hoist the ChatPage to prevent it from rebuilding
+  late final Widget _chatPage;
+
   @override
   void initState() {
     super.initState();
+
+    // Initialize the ChatPage once
+    _chatPage = const ChatPage();
+
     _animationController = AnimationController(
       duration: const Duration(milliseconds: 400),
       vsync: this,
@@ -213,7 +220,7 @@ class _MainPageState extends State<MainPage> with TickerProviderStateMixin {
       ),
       body: FadeTransition(
         opacity: _fadeAnimation,
-        child: const ChatPage(),
+        child: _chatPage,
       ),
     );
   }


### PR DESCRIPTION
This commit introduces a major refactor of the web search functionality and fixes two UI blinking issues.

Web Search Refactor:
- The `WebSearchMessage` has been removed and its functionality merged into the main `Message` model. This allows AI summaries and their sources to be contained within a single message bubble.
- The UI has been updated to display a "Sources" bar with favicons below web search responses.
- A new bottom sheet shows detailed source information when the "Sources" bar is tapped.
- Web search results are now correctly persisted in the chat history.

UI Blinking Fixes:
- Fixed a "blink" on app startup by adding a 200ms delay to the chat history loading shimmer, preventing it from flashing on screen during fast data loads.
- Fixed an issue where the chat page would blink when the sidebar was opened by hoisting the `ChatPage` widget out of the `build` method in `MainPage`, preventing unnecessary rebuilds.