### PR TITLE
feat: Refactor web search, fix UI, and resolve build errors

### DIFF
--- a/lib/core/models/chart_message_model.dart
+++ b/lib/core/models/chart_message_model.dart
@@ -13,6 +13,7 @@ class ChartMessage extends Message {
     required super.timestamp,
     super.isStreaming = false,
     super.hasError = false,
+    super.webSearchResult,
   }) : super(
           content: chartConfig,
           type: MessageType.assistant,
@@ -36,6 +37,7 @@ class ChartMessage extends Message {
     DateTime? timestamp,
     bool? isStreaming,
     bool? hasError,
+    WebSearchResult? webSearchResult,
     String? prompt,
     String? chartConfig,
     String? chartType,
@@ -50,6 +52,7 @@ class ChartMessage extends Message {
       timestamp: timestamp ?? this.timestamp,
       isStreaming: isStreaming ?? this.isStreaming,
       hasError: hasError ?? this.hasError,
+      webSearchResult: webSearchResult ?? this.webSearchResult,
     );
   }
 

--- a/lib/core/models/diagram_message_model.dart
+++ b/lib/core/models/diagram_message_model.dart
@@ -11,6 +11,7 @@ class DiagramMessage extends Message {
     required DateTime timestamp,
     bool isStreaming = false,
     bool hasError = false,
+    super.webSearchResult,
   }) : super(
     id: id,
     content: mermaidCode,
@@ -58,6 +59,7 @@ class DiagramMessage extends Message {
     DateTime? timestamp,
     bool? isStreaming,
     bool? hasError,
+    WebSearchResult? webSearchResult,
     String? prompt,
     String? mermaidCode,
   }) {
@@ -70,6 +72,7 @@ class DiagramMessage extends Message {
       timestamp: timestamp ?? this.timestamp,
       isStreaming: isStreaming ?? this.isStreaming,
       hasError: hasError ?? this.hasError,
+      webSearchResult: webSearchResult ?? this.webSearchResult,
     );
   }
 

--- a/lib/core/models/flashcard_message_model.dart
+++ b/lib/core/models/flashcard_message_model.dart
@@ -39,6 +39,7 @@ class FlashcardMessage extends Message {
     required super.timestamp,
     super.isStreaming = false,
     super.hasError = false,
+    super.webSearchResult,
   }) : super(
           content: flashcards.map((f) => 'Q: ${f.question}\nA: ${f.answer}').join('\n\n'),
           type: MessageType.assistant,
@@ -62,6 +63,7 @@ class FlashcardMessage extends Message {
     DateTime? timestamp,
     bool? isStreaming,
     bool? hasError,
+    WebSearchResult? webSearchResult,
     String? prompt,
     List<FlashcardItem>? flashcards,
   }) {
@@ -72,6 +74,7 @@ class FlashcardMessage extends Message {
       timestamp: timestamp ?? this.timestamp,
       isStreaming: isStreaming ?? this.isStreaming,
       hasError: hasError ?? this.hasError,
+      webSearchResult: webSearchResult ?? this.webSearchResult,
     );
   }
 

--- a/lib/core/models/image_message_model.dart
+++ b/lib/core/models/image_message_model.dart
@@ -17,6 +17,7 @@ class ImageMessage extends Message {
     this.isGenerating = false,
     super.isStreaming = false,
     super.hasError = false,
+    super.webSearchResult,
   });
 
   @override
@@ -27,6 +28,7 @@ class ImageMessage extends Message {
     DateTime? timestamp,
     bool? isStreaming,
     bool? hasError,
+    WebSearchResult? webSearchResult,
     String? imageUrl,
     String? prompt,
     String? model,
@@ -39,6 +41,7 @@ class ImageMessage extends Message {
       timestamp: timestamp ?? this.timestamp,
       isStreaming: isStreaming ?? this.isStreaming,
       hasError: hasError ?? this.hasError,
+      webSearchResult: webSearchResult ?? this.webSearchResult,
       imageUrl: imageUrl ?? this.imageUrl,
       prompt: prompt ?? this.prompt,
       model: model ?? this.model,

--- a/lib/core/models/presentation_message_model.dart
+++ b/lib/core/models/presentation_message_model.dart
@@ -11,6 +11,7 @@ class PresentationMessage extends Message {
     required DateTime timestamp,
     bool isStreaming = false,
     bool hasError = false,
+    super.webSearchResult,
   }) : super(
     id: id,
     content: _slidesToMarkdown(slides),
@@ -69,6 +70,7 @@ class PresentationMessage extends Message {
     DateTime? timestamp,
     bool? isStreaming,
     bool? hasError,
+    WebSearchResult? webSearchResult,
     String? prompt,
     List<PresentationSlide>? slides,
   }) {
@@ -79,6 +81,7 @@ class PresentationMessage extends Message {
       timestamp: timestamp ?? this.timestamp,
       isStreaming: isStreaming ?? this.isStreaming,
       hasError: hasError ?? this.hasError,
+      webSearchResult: webSearchResult ?? this.webSearchResult,
     );
   }
 

--- a/lib/core/models/quiz_message_model.dart
+++ b/lib/core/models/quiz_message_model.dart
@@ -43,6 +43,7 @@ class QuizMessage extends Message {
     required super.timestamp,
     super.isStreaming = false,
     super.hasError = false,
+    super.webSearchResult,
   }) : super(
           content: questions.map((q) => 
             '${q.question}\n${q.options.asMap().entries.map((e) => '${e.key + 1}. ${e.value}').join('\n')}'
@@ -68,6 +69,7 @@ class QuizMessage extends Message {
     DateTime? timestamp,
     bool? isStreaming,
     bool? hasError,
+    WebSearchResult? webSearchResult,
     String? prompt,
     List<QuizQuestion>? questions,
   }) {
@@ -78,6 +80,7 @@ class QuizMessage extends Message {
       timestamp: timestamp ?? this.timestamp,
       isStreaming: isStreaming ?? this.isStreaming,
       hasError: hasError ?? this.hasError,
+      webSearchResult: webSearchResult ?? this.webSearchResult,
     );
   }
 

--- a/lib/core/models/vision_analysis_message_model.dart
+++ b/lib/core/models/vision_analysis_message_model.dart
@@ -11,6 +11,7 @@ class VisionAnalysisMessage extends Message {
     this.analysisPrompt,
     this.analysisResult,
     bool hasError = false,
+    super.webSearchResult,
   }) : super(
           id: id,
           content: analysisResult ?? '',
@@ -28,6 +29,7 @@ class VisionAnalysisMessage extends Message {
     DateTime? timestamp,
     bool? isStreaming,
     bool? hasError,
+    WebSearchResult? webSearchResult,
   }) {
     // For VisionAnalysisMessage, we treat content as analysisResult
     return VisionAnalysisMessage(
@@ -36,6 +38,7 @@ class VisionAnalysisMessage extends Message {
       analysisPrompt: analysisPrompt,
       analysisResult: content ?? this.analysisResult,
       hasError: hasError ?? this.hasError,
+      webSearchResult: webSearchResult ?? this.webSearchResult,
     );
   }
 }

--- a/lib/core/models/vision_message_model.dart
+++ b/lib/core/models/vision_message_model.dart
@@ -15,6 +15,7 @@ class VisionMessage extends Message {
     this.model,
     super.isStreaming = false,
     super.hasError = false,
+    super.webSearchResult,
   });
 
   @override
@@ -25,6 +26,7 @@ class VisionMessage extends Message {
     DateTime? timestamp,
     bool? isStreaming,
     bool? hasError,
+    WebSearchResult? webSearchResult,
     String? model,
     String? imageData,
     String? analysisPrompt,
@@ -36,6 +38,7 @@ class VisionMessage extends Message {
       timestamp: timestamp ?? this.timestamp,
       isStreaming: isStreaming ?? this.isStreaming,
       hasError: hasError ?? this.hasError,
+      webSearchResult: webSearchResult ?? this.webSearchResult,
       model: model ?? this.model,
       imageData: imageData ?? this.imageData,
       analysisPrompt: analysisPrompt ?? this.analysisPrompt,

--- a/lib/core/services/chat_history_service.dart
+++ b/lib/core/services/chat_history_service.dart
@@ -240,21 +240,21 @@ class ChatHistoryService extends ChangeNotifier {
 
         switch (messageType) {
           case 'image':
-            return ImageMessage.fromJson(json, metadata!);
+            return ImageMessage.fromJson(json, metadata ?? {});
           case 'vision':
-            return VisionMessage.fromJson(json, metadata!);
+            return VisionMessage.fromJson(json, metadata ?? {});
           case 'diagram':
-            return DiagramMessage.fromJson(json, metadata!);
+            return DiagramMessage.fromJson(json, metadata ?? {});
           case 'presentation':
-            return PresentationMessage.fromJson(json, metadata!);
+            return PresentationMessage.fromJson(json, metadata ?? {});
           case 'chart':
-            return ChartMessage.fromJson(json, metadata!);
+            return ChartMessage.fromJson(json, metadata ?? {});
           case 'flashcard':
-            return FlashcardMessage.fromJson(json, metadata!);
+            return FlashcardMessage.fromJson(json, metadata ?? {});
           case 'quiz':
-            return QuizMessage.fromJson(json, metadata!);
+            return QuizMessage.fromJson(json, metadata ?? {});
           case 'web_search':
-            return Message.fromJson(json, metadata);
+            return Message.fromJson(json, metadata ?? {});
           default:
             return Message(
               id: json['id'],

--- a/lib/features/chat/widgets/message_bubble.dart
+++ b/lib/features/chat/widgets/message_bubble.dart
@@ -893,7 +893,15 @@ class _MessageBubbleState extends State<MessageBubble>
                   itemCount: sources.length,
                   itemBuilder: (context, index) {
                     final source = sources[index];
-                    final domain = _getDomain(source.link);
+                    String? link;
+                    if (source is WebPageResult) {
+                      link = source.link;
+                    } else if (source is NewsArticleResult) {
+                      link = source.link;
+                    }
+                    if (link == null) return const SizedBox.shrink();
+
+                    final domain = _getDomain(link);
                     if (domain == null) return const SizedBox.shrink();
 
                     return Padding(
@@ -936,28 +944,29 @@ class _MessageBubbleState extends State<MessageBubble>
           maxChildSize: 0.9,
           expand: false,
           builder: (context, scrollController) {
-            return _SourcesSheet(result: result, scrollController: scrollController);
+            return _SourcesSheet(
+              result: result,
+              scrollController: scrollController,
+              getDomain: _getDomain, // Pass the function here
+            );
           },
         );
       },
     );
   }
 
-  String? _getDomain(String urlString) {
-    try {
-      final uri = Uri.parse(urlString);
-      return uri.host;
-    } catch (e) {
-      return null;
-    }
-  }
 }
 
 class _SourcesSheet extends StatelessWidget {
   final WebSearchResult result;
   final ScrollController scrollController;
+  final String? Function(String) getDomain;
 
-  const _SourcesSheet({required this.result, required this.scrollController});
+  const _SourcesSheet({
+    required this.result,
+    required this.scrollController,
+    required this.getDomain,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -1019,7 +1028,7 @@ class _SourcesSheet extends StatelessWidget {
 
   Widget _buildWebPageTile(BuildContext context, WebPageResult page) {
     final theme = Theme.of(context);
-    final domain = _getDomain(page.link);
+    final domain = getDomain(page.link);
 
     return Card(
       margin: const EdgeInsets.symmetric(vertical: 6),


### PR DESCRIPTION
This commit introduces a major refactor of the web search functionality, fixes two UI blinking issues, and resolves several build errors.

Web Search Refactor:
- The `WebSearchMessage` class has been removed and its functionality merged into the main `Message` model. This allows AI summaries and their sources to be contained within a single message bubble.
- The UI has been updated to display a "Sources" bar with favicons below web search responses.
- A new bottom sheet shows detailed source information when the "Sources" bar is tapped.
- Web search results are now correctly persisted in the chat history.

UI Blinking Fixes:
- Fixed a "blink" on app startup by adding a 200ms delay to the chat history loading shimmer, preventing it from flashing on screen during fast data loads.
- Fixed an issue where the chat page would blink when the sidebar was opened by hoisting the `ChatPage` widget out of the `build` method in `MainPage`, preventing unnecessary rebuilds.

Build Error Fixes:
- Corrected the `copyWith` method signature in all `Message` subclasses to match the base class.
- Resolved a nullable type mismatch in `ChatHistoryService` by safely handling potentially null metadata.
- Fixed an "undefined getter" error in `MessageBubble` by adding a type check before accessing properties on mixed-type objects.