### PR TITLE
feat: Refactor web search, fix UI, and resolve build errors

### DIFF
--- a/lib/core/models/chart_message_model.dart
+++ b/lib/core/models/chart_message_model.dart
@@ -1,4 +1,5 @@
 import 'message_model.dart';
+import 'web_search_result_model.dart';
 
 class ChartMessage extends Message {
   final String prompt;

--- a/lib/core/models/diagram_message_model.dart
+++ b/lib/core/models/diagram_message_model.dart
@@ -1,4 +1,5 @@
 import 'message_model.dart';
+import 'web_search_result_model.dart';
 
 class DiagramMessage extends Message {
   final String prompt;

--- a/lib/core/models/flashcard_message_model.dart
+++ b/lib/core/models/flashcard_message_model.dart
@@ -1,4 +1,5 @@
 import 'message_model.dart';
+import 'web_search_result_model.dart';
 
 class FlashcardItem {
   final String question;

--- a/lib/core/models/image_message_model.dart
+++ b/lib/core/models/image_message_model.dart
@@ -1,4 +1,5 @@
 import 'message_model.dart';
+import 'web_search_result_model.dart';
 
 class ImageMessage extends Message {
   final String imageUrl;

--- a/lib/core/models/presentation_message_model.dart
+++ b/lib/core/models/presentation_message_model.dart
@@ -1,4 +1,5 @@
 import 'message_model.dart';
+import 'web_search_result_model.dart';
 
 class PresentationMessage extends Message {
   final String prompt;

--- a/lib/core/models/quiz_message_model.dart
+++ b/lib/core/models/quiz_message_model.dart
@@ -1,4 +1,5 @@
 import 'message_model.dart';
+import 'web_search_result_model.dart';
 
 class QuizQuestion {
   final String question;

--- a/lib/core/models/vision_analysis_message_model.dart
+++ b/lib/core/models/vision_analysis_message_model.dart
@@ -1,4 +1,5 @@
 import 'message_model.dart';
+import 'web_search_result_model.dart';
 
 class VisionAnalysisMessage extends Message {
   final bool isAnalyzing;

--- a/lib/core/models/vision_message_model.dart
+++ b/lib/core/models/vision_message_model.dart
@@ -1,4 +1,5 @@
 import 'message_model.dart';
+import 'web_search_result_model.dart';
 
 class VisionMessage extends Message {
   final String imageData;

--- a/lib/features/chat/widgets/message_bubble.dart
+++ b/lib/features/chat/widgets/message_bubble.dart
@@ -1335,6 +1335,15 @@ class _ImageGenerationShimmerState extends State<_ImageGenerationShimmer>
       },
     );
   }
+
+  String? _getDomain(String urlString) {
+    try {
+      final uri = Uri.parse(urlString);
+      return uri.host;
+    } catch (e) {
+      return null;
+    }
+  }
 }
 
 class _ShimmerPainter extends CustomPainter {


### PR DESCRIPTION
This commit introduces a major refactor of the web search functionality, fixes two UI blinking issues, and resolves several build errors.

Web Search Refactor:
- The `WebSearchMessage` class has been removed and its functionality merged into the main `Message` model. This allows AI summaries and their sources to be contained within a single message bubble.
- The UI has been updated to display a "Sources" bar with favicons below web search responses.
- A new bottom sheet shows detailed source information when the "Sources" bar is tapped.
- Web search results are now correctly persisted in the chat history.

UI Blinking Fixes:
- Fixed a "blink" on app startup by adding a 200ms delay to the chat history loading shimmer, preventing it from flashing on screen during fast data loads.
- Fixed an issue where the chat page would blink when the sidebar was opened by hoisting the `ChatPage` widget out of the `build` method in `MainPage`, preventing unnecessary rebuilds.

Build Error Fixes:
- Corrected the `copyWith` method signature in all `Message` subclasses to match the base class.
- Resolved a nullable type mismatch in `ChatHistoryService` by safely handling potentially null metadata.
- Fixed an "undefined getter" error in `MessageBubble` by adding a type check.
- Added missing import statements for `WebSearchResult`.
- Restored a deleted helper method (`_getDomain`) in `MessageBubble`.