### PR TITLE
feat: Refactor web search, fix UI, and resolve build errors

### DIFF
--- a/lib/features/chat/widgets/message_bubble.dart
+++ b/lib/features/chat/widgets/message_bubble.dart
@@ -870,7 +870,6 @@ class _MessageBubbleState extends State<MessageBubble>
           borderRadius: BorderRadius.circular(8),
         ),
         child: Row(
-          mainAxisSize: MainAxisSize.min,
           children: [
             Icon(
               CupertinoIcons.globe,


### PR DESCRIPTION
This commit introduces a major refactor of the web search functionality, fixes two UI blinking issues, and resolves several build errors.

Web Search Refactor:
- The `WebSearchMessage` class has been removed and its functionality merged into the main `Message` model. This allows AI summaries and their sources to be contained within a single message bubble.
- The UI has been updated to display a "Sources" bar with favicons below web search responses.
- A new bottom sheet shows detailed source information when the "Sources" bar is tapped.
- Web search results are now correctly persisted in the chat history.

UI Blinking Fixes:
- Fixed a "blink" on app startup by adding a 200ms delay to the chat history loading shimmer, preventing it from flashing on screen during fast data loads.
- Fixed an issue where the chat page would blink when the sidebar was opened by hoisting the `ChatPage` widget out of the `build` method in `MainPage`, preventing unnecessary rebuilds.

Build Error Fixes:
- Corrected the `copyWith` method signature in all `Message` subclasses to match the base class.
- Resolved a nullable type mismatch in `ChatHistoryService` by safely handling potentially null metadata.
- Fixed an "undefined getter" error in `MessageBubble` by adding a type check and correctly placing the helper method.
- Added missing import statements for `WebSearchResult` across multiple model files.